### PR TITLE
SYS-787: Change all qdb_password references to qdb_db_password

### DIFF
--- a/charts/lbs/Chart.yaml
+++ b/charts/lbs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for LBS Django applications, including QDB UI
 name: lbs
-version: 0.0.8
+version: 0.0.9

--- a/charts/lbs/templates/secrets.yaml
+++ b/charts/lbs/templates/secrets.yaml
@@ -10,5 +10,5 @@ type: Opaque
 data:
   DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
   DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
-  QDB_PASSWORD: {{ .Values.django.env.qdb_password | b64enc | quote }}
+  QDB_DB_PASSWORD: {{ .Values.django.env.qdb_db_password | b64enc | quote }}
 {{ end }}

--- a/charts/lbs/values.yaml
+++ b/charts/lbs/values.yaml
@@ -64,7 +64,7 @@ django:
     # Include below if enabled: "true"
     #  db_password: ""
     #  django_secret_key: ""
-    #  qdb_password: ""
+    #  qdb_db_password: ""
   
 
 resources: {}


### PR DESCRIPTION
This fixes a problem surfaced in SYS-787, where the helm charts used variables `qdb_password` instead of `qdb_db_password`. Since the application itself consistently uses `QDB_DB_*`, I'm updating the charts to match.